### PR TITLE
Fix dangling .Values.env.vars preventing to install chart

### DIFF
--- a/charts/trivy-operator/Chart.yaml
+++ b/charts/trivy-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trivy-operator
 description: A Helm chart for trivy-operator
 type: application
-version: 2.3
+version: 2.3.1
 appVersion: "1.16.0"
 kubeVersion: ">=1.19.x-0"
 keywords:

--- a/charts/trivy-operator/templates/3-deployment.yaml
+++ b/charts/trivy-operator/templates/3-deployment.yaml
@@ -44,9 +44,6 @@ spec:
         - name: GITHUB_TOKEN
           value: "{{ .Values.githubToken.token }}"
 {{- end }}
-{{- if .Values.env.vars }}
-{{ toYaml .Values.env.vars | indent 8 }}
-{{- end }}
 {{- if .Values.storage.enabled }}
         volumeMounts:
         - name: cache


### PR DESCRIPTION
Patch to test out changes for https://github.com/devopstales/trivy-operator/issues/17

It is very inconvenient to (re)install charts that changes without version bump, so I changed minor version of chart (assuming future semver-compatible version bumps).